### PR TITLE
Added object links to the registries table in the Index.html

### DIFF
--- a/CSS/specifications.css
+++ b/CSS/specifications.css
@@ -18,6 +18,16 @@
         margin: 0;
     }
 
+        #releases-table > tbody > tr > td:nth-child(1) ul > li {
+            position: relative;
+            text-align: left;
+        }
+
+        #releases-table > tbody > tr > td:nth-child(1) div {
+            float: left;
+            margin: 5px 5px 5px 5px;
+        }
+
         #releases-table > tbody > tr > td ul > li {
             position: relative;
             text-align: center;

--- a/index.html
+++ b/index.html
@@ -614,8 +614,15 @@
                             </div>
                             <div>
                                 <ul>
-                                    <li><a href="http://openmobilealliance.org/release/ObjLwM2M%20ACL/">ObjLwM2M ACL</a></li>
-                                    <li><a href="http://openmobilealliance.org/release/ObjLwM2M%20Conn%20Mon/">ObjLwM2M Conn Mon</a></li>
+                                    <li><a href="http://openmobilealliance.org/release/ObjLwM2M_ACL/">ObjLwM2M ACL</a></li>
+                                    <li><a href="http://openmobilealliance.org/release/ObjLwM2M_Conn_Mon/">ObjLwM2M Conn Mon</a></li>
+                                    <li><a href="http://openmobilealliance.org/release/ObjLwM2M_Conn_Stat/">ObjLwM2M Conn Stat</a></li>
+                                    <li><a href="http://openmobilealliance.org/release/ObjLwM2M_Device/">ObjLwM2M Device</a></li>
+                                    <li><a href="http://openmobilealliance.org/release/ObjLwM2M_Firmware/">ObjLwM2M Firmware</a></li>
+                                    <li><a href="http://openmobilealliance.org/release/ObjLwM2M_Location/">ObjLwM2M Location</a></li>
+                                    <li><a href="http://openmobilealliance.org/release/ObjLwM2M_OSCORE/">ObjLwM2M OSCORE</a></li>
+                                    <li><a href="http://openmobilealliance.org/release/ObjLwM2M_Security/">ObjLwM2M Security</a></li>
+                                    <li><a href="http://openmobilealliance.org/release/ObjLwM2M_Server/">ObjLwM2M Server</a></li>
                                 </ul>
                             </div>
                         </td>

--- a/index.html
+++ b/index.html
@@ -606,10 +606,18 @@
                     </tr>
                     <tr>
                         <td>
-                            <a href="/release/LightweightM2M">OMA LightweightM2M (LwM2M)</a><br>
-                            <a href="./OMNA/LwM2M/LwM2MRegistry.html" target="_blank">
-                                <img src="./Images/OMA-129 Lightweight M2M Logo_RGB_full.jpg" alt="LwM2M Logo" style="width:200px;height:100px;">
-                            </a>
+                            <div>
+                                <a href="/release/LightweightM2M">OMA LightweightM2M (LwM2M)</a><br>
+                                <a href="./OMNA/LwM2M/LwM2MRegistry.html" target="_blank">
+                                    <img src="./Images/OMA-129 Lightweight M2M Logo_RGB_full.jpg" alt="LwM2M Logo" style="width:200px;height:100px;">
+                                </a>
+                            </div>
+                            <div>
+                                <ul>
+                                    <li><a href="http://openmobilealliance.org/release/ObjLwM2M%20ACL/">ObjLwM2M ACL</a></li>
+                                    <li><a href="http://openmobilealliance.org/release/ObjLwM2M%20Conn%20Mon/">ObjLwM2M Conn Mon</a></li>
+                                </ul>
+                            </div>
                         </td>
                         <td>
                             <a href="http://www.openmobilealliance.org/wp/Overviews/lightweightm2m_overview.html" class="orange">Overview</a><br>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openmobilealliance.github.io",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Open Mobile Alliance Work Program Pages",
   "main": "index.html",
   "scripts": {


### PR DESCRIPTION
I've made it so that if you use DIVs in the first column of the registries table, they will be arranged left to right (float: left) rather than on top of each other.

This is controlled in the CSS.

You can use the unordered-list (ul) and list items (li) tags to make your list of object links (you can see this in the code change).