### PR TITLE
Resource table updated

### DIFF
--- a/OMNA/LwM2M/LwM2MRegistry.html
+++ b/OMNA/LwM2M/LwM2MRegistry.html
@@ -312,15 +312,16 @@
             <h2>LwM2M Resources</h2>
             <h3 id="resources">Reusable Resources</h3>
             <p><code>range: (2048 - 26240)</code></p>
+            <p><strong>Note:</strong> The value of attributes marked (*) <strong>CANNOT</strong> be changed when the Reusable Resource is defined inside of an Object.</p>
             <table id="commonobjects_tbl" class="descriptive-table">
                 <thead>
                     <tr>
-                        <th>ResourceID </th>
-                        <th>Technical Spec<br /></th>
-                        <th>Access Type/Operation</th>
-                        <th>Type</th>
-                        <th>Range/Enumeration</th>
-                        <th>Units</th>
+                        <th>ResourceID*</th>
+                        <th>Name/Technical Spec*<br /></th>
+                        <th>Access Type/Operation*</th>
+                        <th>Type*</th>
+                        <th>Range/Enumeration*</th>
+                        <th>Units*</th>
                         <th>Submitter</th>
                         <th>Description</th>
                     </tr>


### PR DESCRIPTION
Resource table updated with ```*``` to denote that they cannot be changed
Note added to highlight Reusable resource is defined