### PR TITLE
Replace T-Mobile Ericsson White Paper link with new link

### DIFF
--- a/public_documents.html
+++ b/public_documents.html
@@ -89,7 +89,7 @@
                     <td>
                         <ul>
                             <li>
-                                <a href="https://www.omaspecworks.org/wp-content/uploads/2018/10/Whitepaper-11.1.18.pdf">OMA Lightweight M2M 1.1:Managing Non-IP Devices in Cellular IoT Networks</a>
+                                <a href="https://www.omaspecworks.org/managing_non-ip_devices_in_cellular_iot_networks/">OMA Lightweight M2M 1.1:Managing Non-IP Devices in Cellular IoT Networks</a>
                             </li>
                             <li>
                                 <a href="https://www.omaspecworks.org/whitepaper-12-5-2018/">OMA Lightweight M2M 5G, IoT, UN-SDG</a>


### PR DESCRIPTION
New link has a name and not the original date.